### PR TITLE
Fix(brew): `sha "digest" => :tag` is deprecated.

### DIFF
--- a/tunnelto.rb
+++ b/tunnelto.rb
@@ -1,19 +1,22 @@
+# typed: false
+# frozen_string_literal: true
+
 class Tunnelto < Formula
   desc "Expose your local web server to the internet with a public url: https://tunnelto.dev"
   homepage "https://github.com/agrinman/tunnelto"
   url "https://github.com/agrinman/tunnelto/archive/0.1.14.zip"
   sha256 "c67618f6766c71f50e2e6025bc48e5cd2d4eff8690c2700cd7140ab2d227eb00"
 
+  bottle do
+    root_url "https://github.com/agrinman/tunnelto/releases/download/0.1.14"
+    sha256 catalina: "e6fc81ad5561e55356fd54ba87687300fa617764ac950ded7ae5bf235cbacb0b"
+    sha256 big_sur:  "e6fc81ad5561e55356fd54ba87687300fa617764ac950ded7ae5bf235cbacb0b"
+  end
+
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--bin", "tunnelto", "--locked", "--root", "#{prefix}", "--path", "./tunnelto"
-  end
-
-  bottle do
-    root_url "https://github.com/agrinman/tunnelto/releases/download/0.1.14"
-    sha256 "e6fc81ad5561e55356fd54ba87687300fa617764ac950ded7ae5bf235cbacb0b" => :catalina
-    sha256 "e6fc81ad5561e55356fd54ba87687300fa617764ac950ded7ae5bf235cbacb0b" => :big_sur    
+    system "cargo", "install", "--bin", "tunnelto", "--locked", "--root", prefix.to_s, "--path", "./tunnelto"
   end
 
   test do

--- a/tunnelto.rb.template
+++ b/tunnelto.rb.template
@@ -4,16 +4,16 @@ class Tunnelto < Formula
   url "https://github.com/agrinman/tunnelto/archive/_VERSION_.zip"
   sha256 "_CODE_SHA2_"
 
+  bottle do
+    root_url "https://github.com/agrinman/tunnelto/releases/download/_VERSION_"
+    sha256 catalina:  "_BIN_SHA2_"
+    sha256 big_sur: "_BIN_SHA2_"
+  end
+
   depends_on "rust" => :build
 
   def install
     system "cargo", "install", "--bin", "tunnelto", "--locked", "--root", "#{prefix}", "--path", "./tunnelto"
-  end
-
-  bottle do
-    root_url "https://github.com/agrinman/tunnelto/releases/download/_VERSION_"
-    sha256 "_BIN_SHA2_" => :catalina
-    sha256 "_BIN_SHA2_" => :big_sur    
   end
 
   test do

--- a/wormhole.rb
+++ b/wormhole.rb
@@ -1,18 +1,21 @@
+# typed: false
+# frozen_string_literal: true
+
 class Wormhole < Formula
-  desc "expose your local web server to the internet with a public url"
+  desc "Expose your local web server to the internet with a public url"
   homepage "https://github.com/agrinman/wormhole"
   url "https://github.com/agrinman/wormhole/archive/0.1.5.zip"
   sha256 "11e36f7199e7a4b490814ae03a752c603e0870c7d9faa4707fc02039b111ba69"
 
+  bottle do
+    root_url "https://github.com/agrinman/wormhole/releases/download/0.1.5"
+    sha256 catalina: "944ebc5e1a464f562b0ddca2b34da3738c04086952426db22456916b58d3e297"
+  end
+
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--bin", "wormhole", "--locked", "--root", "#{prefix}", "--path", "."
-  end
-
-  bottle do
-    root_url "https://github.com/agrinman/wormhole/releases/download/0.1.5"
-    sha256 "944ebc5e1a464f562b0ddca2b34da3738c04086952426db22456916b58d3e297" => :catalina
+    system "cargo", "install", "--bin", "wormhole", "--locked", "--root", prefix.to_s, "--path", "."
   end
 
   test do


### PR DESCRIPTION
Homebrew kept generating the following messages in the terminal, so I took a closer look, and realizing it would be a straightforward fix, I just went ahead and made the updates. 

* Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the agrinman/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/agrinman/homebrew-tap/tunnelto.rb:15

* Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the agrinman/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/agrinman/homebrew-tap/tunnelto.rb:16